### PR TITLE
Add GPU support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,9 @@
 include LICENSE
 include README.rst
 include bin/cythonize.py
+include lightnet/_darknet/Makefile
 recursive-include lightnet/_darknet *.c
+recursive-include lightnet/_darknet *.cu
 recursive-include lightnet/_darknet *.h
 recursive-include lightnet/data *.cfg
 recursive-include lightnet/data *.data

--- a/lightnet/_darknet/Makefile
+++ b/lightnet/_darknet/Makefile
@@ -1,0 +1,101 @@
+GPU=0
+CUDNN=0
+OPENCV=0
+OPENMP=0
+DEBUG=0
+
+ARCH= -gencode arch=compute_30,code=sm_30 \
+      -gencode arch=compute_35,code=sm_35 \
+      -gencode arch=compute_50,code=[sm_50,compute_50] \
+      -gencode arch=compute_52,code=[sm_52,compute_52]
+#      -gencode arch=compute_20,code=[sm_20,sm_21] \ This one is deprecated?
+
+# This is what I use, uncomment if you know your arch and want to specify
+# ARCH= -gencode arch=compute_52,code=compute_52
+
+VPATH=./
+SLIB=libdarknet.so
+ALIB=libdarknet.a
+EXEC=darknet
+OBJDIR=./obj/
+
+CC=gcc
+NVCC=nvcc
+AR=ar
+ARFLAGS=rcs
+OPTS=-Ofast
+LDFLAGS= -lm -pthread
+COMMON= -I.
+CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC
+
+ifeq ($(OPENMP), 1)
+CFLAGS+= -fopenmp
+endif
+
+ifeq ($(DEBUG), 1)
+OPTS=-O0 -g
+endif
+
+CFLAGS+=$(OPTS)
+
+ifeq ($(OPENCV), 1)
+COMMON+= -DOPENCV
+CFLAGS+= -DOPENCV
+LDFLAGS+= `pkg-config --libs opencv`
+COMMON+= `pkg-config --cflags opencv`
+endif
+
+ifeq ($(GPU), 1)
+COMMON+= -DGPU -I/usr/local/cuda/include/
+CFLAGS+= -DGPU
+LDFLAGS+= -L/usr/local/cuda/lib64 -lcuda -lcudart -lcublas -lcurand
+endif
+
+ifeq ($(CUDNN), 1)
+COMMON+= -DCUDNN
+CFLAGS+= -DCUDNN
+LDFLAGS+= -lcudnn
+endif
+
+OBJ=gemm.o utils.o cuda.o deconvolutional_layer.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o detection_layer.o route_layer.o box.o normalization_layer.o avgpool_layer.o layer.o local_layer.o shortcut_layer.o activation_layer.o rnn_layer.o gru_layer.o crnn_layer.o demo.o batchnorm_layer.o region_layer.o reorg_layer.o tree.o  lstm_layer.o
+EXECOBJA=captcha.o lsd.o super.o art.o tag.o cifar.o go.o rnn.o segmenter.o regressor.o classifier.o coco.o yolo.o detector.o nightmare.o attention.o darknet.o
+ifeq ($(GPU), 1)
+LDFLAGS+= -lstdc++
+OBJ+=convolutional_kernels.o deconvolutional_kernels.o activation_kernels.o im2col_kernels.o col2im_kernels.o blas_kernels.o crop_layer_kernels.o dropout_layer_kernels.o maxpool_layer_kernels.o avgpool_layer_kernels.o
+endif
+
+EXECOBJ = $(addprefix $(OBJDIR), $(EXECOBJA))
+OBJS = $(addprefix $(OBJDIR), $(OBJ))
+DEPS = $(wildcard ./*.h) Makefile ./darknet.h
+
+#all: obj backup results $(SLIB) $(ALIB) $(EXEC)
+all: obj $(ALIB)
+
+
+$(EXEC): $(EXECOBJ) $(ALIB)
+	$(CC) $(COMMON) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(ALIB)
+
+$(ALIB): $(OBJS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(SLIB): $(OBJS)
+	$(CC) $(CFLAGS) -shared $^ -o $@ $(LDFLAGS)
+
+$(OBJDIR)%.o: %.c $(DEPS)
+	$(CC) $(COMMON) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR)%.o: %.cu $(DEPS)
+	$(NVCC) $(ARCH) $(COMMON) --compiler-options "$(CFLAGS)" -c $< -o $@
+
+obj:
+	mkdir -p obj
+backup:
+	mkdir -p backup
+results:
+	mkdir -p results
+
+.PHONY: clean
+
+clean:
+	rm -rf $(OBJS) $(SLIB) $(ALIB) $(EXEC) $(EXECOBJ)
+


### PR DESCRIPTION
distutils cannot compile CUDA code by default. Therefore, this commit
uses `make` to build darknet with GPU and CUDNN flags.

`GPU=1 pip install lightnet` installs lightnet with GPU support.
`CUDNN=1 pip install lightnet` installs lightnet with CUDNN support.