### PR TITLE
Add OpenBLAS requirement to the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,12 @@ LightNet's features include:
 **Package managers** pip (source packages only)
 ==================== ===
 
+LightNet requires an installation of `OpenBLAS <https://www.openblas.net/>`_:
+
+.. code:: bash
+
+    sudo apt-get install libopenblas-dev
+
 LightNet can be installed via pip:
 
 .. code:: bash


### PR DESCRIPTION
This is really minor, but I ran into a compilation issue before I installed OpenBLAS. I'm not sure how you'd like to declare prerequisites, but I thought a PR would be nicer than an issue. I could also see this going up above in the list with OS, Python versions, and pip.